### PR TITLE
Add agent templates and workflow YAML

### DIFF
--- a/agent_templates/agent_steps.yaml
+++ b/agent_templates/agent_steps.yaml
@@ -1,0 +1,22 @@
+workflow:
+  name: prompt_workflow
+  description: Multi-agent process to create and refine prompts
+  steps:
+    - id: generate_prompt
+      agent: prompt-engineering-agent
+      trigger: user_request
+      actions:
+        - use_tools: [PythonExecute, WebSearch, FileSaver]
+        - save_output: initial_prompt.md
+    - id: evaluate_prompt
+      agent: prompt-quality-evaluator-agent
+      trigger: generate_prompt.completed
+      actions:
+        - compute_score
+        - save_output: evaluation_report.md
+    - id: optimize_prompt
+      agent: prompt-optimizer-agent
+      trigger: "evaluate_prompt.score < 0.8"
+      actions:
+        - refine_prompt
+        - save_output: optimized_prompt.md

--- a/agent_templates/prompt_engineering_agent.md
+++ b/agent_templates/prompt_engineering_agent.md
@@ -1,0 +1,27 @@
+# Prompt Engineering Agent Template
+
+## Role
+Responsible for crafting and refining prompts used by other agents. Works closely with the PlanningAgent to ensure each step has a clear instruction.
+
+## Required Tools
+- `PythonExecute`: run Python snippets to manipulate context or parse data
+- `WebSearch`: gather domain information
+- `FileSaver`: store generated prompts or reference material
+- `Terminate`: finish the session when prompt design is complete
+
+## APIs and MCP Servers
+Uses the configured LLM API from `config.toml` to generate and test prompts. Optionally connects to an MCP (Manus Control Panel) server if one is provided for centralized plan storage.
+
+## Trigger Conditions
+- Activated when the PlanningAgent identifies a step requiring prompt creation or refinement.
+- May also be triggered by a user request for new prompt templates.
+
+## Context Enrichment Strategy
+1. Collect relevant domain knowledge using `WebSearch`.
+2. Summarize findings with `PythonExecute` and store references using `FileSaver`.
+3. Incorporate previous step outputs from the active plan to maintain continuity.
+
+## Custom Instruction Sets
+- Follow best practices for clear, concise prompts.
+- Include brief examples when possible.
+- Emphasize the user goal and required tools in the final prompt text.

--- a/agent_templates/prompt_optimizer_agent.md
+++ b/agent_templates/prompt_optimizer_agent.md
@@ -1,0 +1,27 @@
+# Prompt Optimizer Agent Template
+
+## Role
+Refines prompts based on evaluation feedback, ensuring they meet quality standards and align with the final user goals.
+
+## Required Tools
+- `PythonExecute`: perform text transformations or apply optimization algorithms
+- `WebSearch`: gather best practices from external sources
+- `FileSaver`: archive optimized prompts for later reuse
+- `Terminate`: conclude optimization when target quality is reached
+
+## APIs and MCP Servers
+Uses the configured LLM API to test candidate optimizations. Stores optimized prompts in an MCP server if configured.
+
+## Trigger Conditions
+- Invoked when the Prompt Quality Evaluator reports a suboptimal score.
+- May be triggered periodically for long-running plans to refresh prompts.
+
+## Context Enrichment Strategy
+1. Incorporate evaluator feedback and user requirements.
+2. Search for additional examples or templates via `WebSearch`.
+3. Apply transformations with `PythonExecute` to generate improved variations.
+
+## Custom Instruction Sets
+- Focus on clarity and brevity while preserving essential details.
+- Avoid introducing new requirements not present in the user request.
+- Save final optimized prompts using `FileSaver` before terminating.

--- a/agent_templates/prompt_quality_evaluator_agent.md
+++ b/agent_templates/prompt_quality_evaluator_agent.md
@@ -1,0 +1,26 @@
+# Prompt Quality Evaluator Agent Template
+
+## Role
+Evaluates prompts produced by other agents, ensuring clarity and alignment with the user objective.
+
+## Required Tools
+- `PythonExecute`: compute heuristic scores or run linting scripts
+- `WebSearch`: verify terminology or gather additional context
+- `Terminate`: signal completion when evaluation is finished
+
+## APIs and MCP Servers
+Relies on the same LLM API for generating feedback and uses MCP servers to log evaluation results if available.
+
+## Trigger Conditions
+- Runs automatically after the Prompt Engineering Agent produces a new prompt.
+- May also be invoked when a prompt receives poor feedback from the user.
+
+## Context Enrichment Strategy
+1. Retrieve the candidate prompt from the active plan.
+2. Cross-reference user requirements via `WebSearch` if domain knowledge is lacking.
+3. Compute a quality score using built-in heuristics executed with `PythonExecute`.
+
+## Custom Instruction Sets
+- Provide concise critiques and actionable suggestions.
+- Rate prompts on dimensions such as clarity, completeness, and bias.
+- Recommend specific edits rather than general statements.


### PR DESCRIPTION
## Summary
- add markdown agent templates describing roles, tools, APIs, triggers and context strategy
- document optimizer and evaluator agents
- provide `agent_steps.yaml` with a sample multi-agent workflow

## Testing
- `python -m pip install -r requirements.txt` *(fails: Operation cancelled)*
- `python run_flow.py --test-ollama` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_687af1c081b0833298a84cc87f0c80d7