### PR TITLE
Add side panel terminal UI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,7 @@
 - **Extensibility**: Easily extendable to support new agents, tools, and workflows.
 
 - **Command Line Demo**: `run_flow.py` provides a simple interactive example.
+- **Side Panel Terminal UI**: `side_panel.py` opens a split screen showing agent thoughts and logs in real time.
 ---
 
 ## Installation
@@ -37,6 +38,17 @@
 ---
 
 ## Usage
+
+### Quick Start
+Run the command line demo:
+```bash
+python run_flow.py
+```
+
+Or launch the side panel interface:
+```bash
+python side_panel.py
+```
 
 ### 1. Initialize the Planning Flow
 The `PlanningFlow` class is the core of the framework. It manages agents, plans, and task execution.

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ pydantic_core~=2.27.2
 colorama~=0.4.6
 playwright~=1.50.0
 gradio~=3.40.0
+rich~=13.7.0

--- a/side_panel.py
+++ b/side_panel.py
@@ -1,0 +1,70 @@
+import asyncio
+import time
+
+from rich.console import Console
+from rich.layout import Layout
+from rich.live import Live
+from rich.panel import Panel
+
+from app.agent.manus import Manus
+from app.flow.base import FlowType
+from app.flow.flow_factory import FlowFactory
+from app.logger import logger
+
+
+class SidePanelUI:
+    """Terminal UI that displays agent thoughts and logs in a side panel."""
+
+    def __init__(self):
+        self.console = Console()
+        self.logs: list[str] = []
+        self.thoughts: list[str] = []
+        logger.remove()
+        logger.add(self._log_sink, format="{message}", level="INFO")
+
+    def _log_sink(self, message: str):
+        self.logs.append(message)
+
+    def _render(self) -> Layout:
+        layout = Layout()
+        layout.split_row(
+            Layout(Panel("\n".join(self.thoughts[-20:]), title="Agent Thoughts")),
+            Layout(Panel("\n".join(self.logs[-20:]), title="Logs")),
+        )
+        return layout
+
+    async def run(self):
+        agents = {"manus": Manus()}
+        prompt = input("Enter your prompt: ").strip()
+        if not prompt:
+            logger.warning("Empty prompt provided.")
+            return
+
+        flow = FlowFactory.create_flow(flow_type=FlowType.PLANNING, agents=agents)
+        logger.warning("Processing your request...")
+        start_time = time.time()
+        with Live(self._render(), console=self.console, refresh_per_second=4) as live:
+            task = asyncio.create_task(flow.execute(prompt))
+            while not task.done():
+                self.thoughts = [
+                    f"{msg.role}: {msg.content}"
+                    for msg in agents["manus"].memory.get_recent_messages(20)
+                    if msg.content
+                ]
+                live.update(self._render())
+                await asyncio.sleep(0.5)
+            result = await task
+            self.thoughts = [
+                f"{msg.role}: {msg.content}"
+                for msg in agents["manus"].memory.get_recent_messages(20)
+                if msg.content
+            ]
+            elapsed_time = time.time() - start_time
+            logger.info(f"Request processed in {elapsed_time:.2f} seconds")
+            logger.info(result)
+            live.update(self._render())
+            await asyncio.sleep(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(SidePanelUI().run())


### PR DESCRIPTION
## Summary
- add new `side_panel.py` script implementing a split terminal UI for agent thoughts and logs
- update README with instructions on running the new interface
- include `rich` in requirements for UI rendering

## Testing
- `pre-commit run --files side_panel.py requirements.txt readme.md`
- `python -m py_compile side_panel.py`