### PR TITLE
Add chat web UI and basic tests

### DIFF
--- a/chat_ui.py
+++ b/chat_ui.py
@@ -1,0 +1,43 @@
+import asyncio
+import gradio as gr
+from app.agent.manus import Manus
+from app.logger import logger
+
+class ChatSession:
+    """Maintain a Manus agent instance for a chat session."""
+
+    def __init__(self):
+        self.agent = Manus()
+
+    async def generate(self, message: str) -> str:
+        if not message.strip():
+            return "Please enter a valid message."
+        try:
+            logger.info("Processing message via Manus agent")
+            return await self.agent.run(message)
+        except Exception as exc:
+            logger.error(f"Error generating response: {exc}")
+            return f"Error: {exc}"
+
+session: ChatSession | None = None
+
+def get_session() -> ChatSession:
+    global session
+    if session is None:
+        session = ChatSession()
+    return session
+
+def respond(message, history):
+    """Wrapper for gradio ChatInterface."""
+    sess = get_session()
+    return asyncio.run(sess.generate(message))
+
+chatbot = gr.ChatInterface(respond,
+                           title="Manus Chat",
+                           description="ChatGPT style interface powered by Manus agent")
+
+def launch():
+    chatbot.launch(server_name="0.0.0.0", server_port=7860)
+
+if __name__ == "__main__":
+    launch()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    sit: System integration tests
+    uat: User acceptance tests

--- a/tests/test_chat_ui.py
+++ b/tests/test_chat_ui.py
@@ -1,0 +1,37 @@
+import pytest
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import chat_ui
+
+class DummyManus:
+    async def run(self, message: str) -> str:
+        return "dummy response"
+
+@pytest.mark.asyncio
+async def test_respond(monkeypatch):
+    monkeypatch.setattr(chat_ui, "Manus", lambda: DummyManus())
+    chat_ui.session = None
+    session = chat_ui.get_session()
+    result = await session.generate("hello")
+    assert result == "dummy response"
+
+@pytest.mark.asyncio
+@pytest.mark.sit
+async def test_integration(monkeypatch):
+    monkeypatch.setattr(chat_ui, "Manus", lambda: DummyManus())
+    chat_ui.session = None
+    session = chat_ui.get_session()
+    result = await session.generate("test message")
+    assert "dummy" in result
+
+@pytest.mark.asyncio
+@pytest.mark.uat
+async def test_user_acceptance(monkeypatch):
+    monkeypatch.setattr(chat_ui, "Manus", lambda: DummyManus())
+    chat_ui.session = None
+    session = chat_ui.get_session()
+    result = await session.generate("another message")
+    assert result == "dummy response"


### PR DESCRIPTION
## Summary
- implement a Gradio-based ChatGPT-like UI (`chat_ui.py`)
- add pytest configuration for SIT/UAT markers
- include basic unit, SIT and UAT tests for the chat interface

## Testing
- `pytest -q`