### PR TITLE
Add persistent storage tests and docs

### DIFF
--- a/chat_ui.py
+++ b/chat_ui.py
@@ -2,14 +2,24 @@ import asyncio
 
 import gradio as gr
 
-from app.agent.manus import Manus
 from app.logger import logger
+
+try:
+    from app.agent.manus import Manus as _Manus
+except Exception:  # pragma: no cover - missing heavy deps in tests
+    _Manus = None
+
+Manus = _Manus
 
 
 class ChatSession:
     """Maintain a Manus agent instance for a chat session."""
 
     def __init__(self):
+        global Manus
+        if Manus is None:
+            from app.agent.manus import Manus as _Manus
+            Manus = _Manus
         self.agent = Manus()
 
     async def generate(self, message: str) -> str:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,9 +5,10 @@ The `PlanningFlow` coordinates task execution by invoking different agents. Each
 subclasses `BaseAgent` and can use tools from `ToolCollection` such as `PythonExecute`,
 `WebSearch` and `BrowserUseTool`.
 
-The central planning capability is implemented via the `PlanningTool`, which stores
-plans in memory and tracks step progress. Agents call this tool through the language
-model using function calling to create and update plans.
+The central planning capability is implemented via the `PlanningTool`, which tracks
+step progress and can optionally persist plans to JSON or SQLite files. Agents call
+this tool through the language model using function calling to create, update and
+resume plans.
 
 ```
 User -> PlanningFlow -> [Agents] -> Tools

--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,8 @@ You can extend the framework by:
 Agents are responsible for executing specific steps in a plan. The `get_executor` method selects the appropriate agent based on the step type.
 
 ### 2. **Planning Tool**
-The `PlanningTool` manages plans, including creating, updating, and retrieving plan details.
+The `PlanningTool` manages plans, including creating, updating, and retrieving plan details. Plans can
+optionally be saved to JSON or SQLite files so they can be resumed across sessions.
 
 ### 3. **LLM Integration**
 The framework integrates with an LLM to generate plans and summaries.

--- a/tests/test_planning_tool.py
+++ b/tests/test_planning_tool.py
@@ -1,0 +1,37 @@
+import asyncio
+import json
+import os
+from app.tool.planning import PlanningTool
+import pytest
+
+
+def test_json_persistence(tmp_path):
+    path = tmp_path / "plans.json"
+    tool = PlanningTool(storage_type="json", storage_path=str(path))
+    asyncio.run(tool.execute(command="create", plan_id="p1", title="t", steps=["s1"]))
+    assert path.exists()
+    tool2 = PlanningTool(storage_type="json", storage_path=str(path))
+    assert "p1" in tool2.plans
+
+
+@pytest.mark.asyncio
+@pytest.mark.sit
+async def test_resume_command(tmp_path):
+    path = tmp_path / "plans.json"
+    tool = PlanningTool(storage_type="json", storage_path=str(path))
+    await tool.execute(command="create", plan_id="p1", title="t", steps=["s1"])
+    await tool.execute(command="create", plan_id="p2", title="t2", steps=["x"])
+    await tool.execute(command="set_active", plan_id="p1")
+    await tool.execute(command="resume", plan_id="p2")
+    assert tool._current_plan_id == "p2"
+
+
+@pytest.mark.asyncio
+@pytest.mark.uat
+async def test_sqlite_persistence(tmp_path):
+    path = tmp_path / "plans.db"
+    tool = PlanningTool(storage_type="sqlite", storage_path=str(path))
+    await tool.execute(command="create", plan_id="p1", title="t", steps=["s1"])
+    assert path.exists()
+    tool2 = PlanningTool(storage_type="sqlite", storage_path=str(path))
+    assert "p1" in tool2.plans


### PR DESCRIPTION
## Summary
- make `chat_ui` lazily import `Manus` to avoid heavy dependencies during testing
- document JSON/SQLite plan persistence in README and architecture docs
- add tests covering PlanningTool JSON/SQLite storage and resume command

## Testing
- `pytest -q`