### PR TITLE
Add planning flow tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from app.tool.planning import PlanningTool
+from app.config import config
+
+@pytest.fixture(autouse=True)
+def disable_mcp(monkeypatch):
+    monkeypatch.setattr(config._config, "mcp_config", None)
+    async def _noop(*args, **kwargs):
+        return None
+    monkeypatch.setattr(PlanningTool, "_sync_with_mcp", _noop)

--- a/tests/test_planning_flow.py
+++ b/tests/test_planning_flow.py
@@ -1,0 +1,88 @@
+import asyncio
+import json
+import pytest
+
+from app.flow.planning import PlanningFlow
+from app.tool.planning import PlanningTool
+from app.agent.base import BaseAgent
+from app.llm import LLM
+from app.flow.base import PlanStepStatus
+
+class DummyAgent(BaseAgent):
+    name: str = "dummy"
+    description: str = "d"
+    llm: LLM
+
+    async def step(self) -> str:
+        return "ok"
+
+@pytest.fixture()
+def dummy_flow(monkeypatch):
+    planning_tool = PlanningTool()
+    llm = LLM()
+
+    async def fake_ask_tool(*args, **kwargs):
+        tool_call = type(
+            "TC",
+            (),
+            {
+                "function": type(
+                    "F",
+                    (),
+                    {
+                        "name": "planning",
+                        "arguments": json.dumps(
+                            {
+                                "command": "create",
+                                "title": "Example Plan",
+                                "steps": ["step1", "step2"],
+                            }
+                        ),
+                    },
+                )(),
+            },
+        )
+        return type("Resp", (), {"tool_calls": [tool_call]})()
+
+    monkeypatch.setattr(llm, "ask_tool", fake_ask_tool)
+    agent = DummyAgent(llm=llm)
+    flow = PlanningFlow(
+        agents={"dummy": agent}, llm=llm, planning_tool=planning_tool, plan_id="p1"
+    )
+    return flow
+
+@pytest.mark.asyncio
+async def test_create_initial_plan(dummy_flow):
+    flow = dummy_flow
+    await flow._create_initial_plan("test request")
+    await asyncio.sleep(0)
+    assert "p1" in flow.planning_tool.plans
+    assert flow.planning_tool.plans["p1"]["title"] == "Example Plan"
+
+@pytest.mark.asyncio
+async def test_get_current_step_info(dummy_flow):
+    flow = dummy_flow
+    await flow._create_initial_plan("req")
+    await asyncio.sleep(0)
+    index, info = await flow._get_current_step_info()
+    await asyncio.sleep(0)
+    assert index == 0
+    assert info["text"] == "step1"
+    assert (
+        flow.planning_tool.plans["p1"]["step_statuses"][0]
+        == PlanStepStatus.IN_PROGRESS.value
+    )
+
+@pytest.mark.asyncio
+async def test_mark_step_completed(dummy_flow):
+    flow = dummy_flow
+    await flow._create_initial_plan("req")
+    await asyncio.sleep(0)
+    index, _ = await flow._get_current_step_info()
+    flow.current_step_index = index
+    await flow._mark_step_completed()
+    await asyncio.sleep(0)
+    assert (
+        flow.planning_tool.plans["p1"]["step_statuses"][index]
+        == PlanStepStatus.COMPLETED.value
+    )


### PR DESCRIPTION
## Summary
- add tests for planning flow functions
- disable MCP sync in tests via autouse fixture

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ccc18fd6883329e9217ddd8045c7b