### PR TITLE
Harden CLI and document agentic framework

### DIFF
--- a/app/schema.py
+++ b/app/schema.py
@@ -96,23 +96,23 @@ class Message(BaseModel):
     @classmethod
     def user_message(cls, content: str) -> "Message":
         """Create a user message"""
-        return cls(role=Role.USER, content=content)
+        return cls(role=Role.USER.value, content=content)
 
     @classmethod
     def system_message(cls, content: str) -> "Message":
         """Create a system message"""
-        return cls(role=Role.SYSTEM, content=content)
+        return cls(role=Role.SYSTEM.value, content=content)
 
     @classmethod
     def assistant_message(cls, content: Optional[str] = None) -> "Message":
         """Create an assistant message"""
-        return cls(role=Role.ASSISTANT, content=content)
+        return cls(role=Role.ASSISTANT.value, content=content)
 
     @classmethod
     def tool_message(cls, content: str, name, tool_call_id: str) -> "Message":
         """Create a tool message"""
         return cls(
-            role=Role.TOOL, content=content, name=name, tool_call_id=tool_call_id
+            role=Role.TOOL.value, content=content, name=name, tool_call_id=tool_call_id
         )
 
     @classmethod

--- a/chat_ui.py
+++ b/chat_ui.py
@@ -23,6 +23,7 @@ class ChatSession:
 
             Manus = _Manus
         self.agent = Manus()
+        logger.info("Chat session initialized")
 
     async def generate(self, message: str) -> str:
         if not message.strip():

--- a/docs/agentic_framework.md
+++ b/docs/agentic_framework.md
@@ -1,0 +1,23 @@
+# Agentic System Framework
+
+This document outlines a domain independent blueprint for building reliable and scalable agent based systems. The guidance distils the core design principles used throughout this project.
+
+## 1. Parahelp SOP
+Standardised prompt files (`.prompt.yaml`) capture role, objective, KPIs, output format and constraints. Versioning these assets allows consistent agent behaviour and easy onboarding for new workflows.
+
+## 2. Prompt Folding
+Break down complex projects into epics, features, user stories and tasks. Each prompt only needs the context relevant to its task which keeps reasoning efficient and enables the use of small models when appropriate.
+
+## 3. Prompt Chains
+Multiple specialised agents collaborate across planning, execution and evaluation stages. Orchestrators like `ChainOrchestrator` or `ReflexionAgent` maintain traceability of reasoning and provide accountability for every step.
+
+## 4. Prompt Library
+All prompts live in a central library with version history and quality notes. Reusable snippets and annotations speed up iteration and allow quick rollback should regressions appear.
+
+## 5. Debug Log Agent
+An internal logging agent records ambiguities, hallucinations and failures. Structured logs with confidence scores help diagnose errors and trigger fallbacks when needed.
+
+## 6. FDE Agent Collaboration
+Agents are grouped by role – planner, builder, tester, deployer and reflexion – mirroring the standard development lifecycle. Clear APIs and isolated domains reduce coupling and optimise multi agent communication.
+
+Following these principles promotes modular, reliable and human aligned AI assistants that can evolve from small prototypes to enterprise scale deployments.

--- a/readme.md
+++ b/readme.md
@@ -124,7 +124,7 @@ print(wf["name"])
 
 
 ## Documentation
-Additional information including the architecture overview, design goals and roadmap can be found in the [docs](./docs) directory. See [usage_demo.md](docs/usage_demo.md) for a CLI example. The [prompt_library.md](docs/prompt_library.md) file describes the standardized prompt templates. Domain workflows are listed in [domain_workflow_list.md](agent_templates/domain_workflow_list.md).
+Additional information including the architecture overview, design goals and roadmap can be found in the [docs](./docs) directory. See [usage_demo.md](docs/usage_demo.md) for a CLI example. The [prompt_library.md](docs/prompt_library.md) file describes the standardized prompt templates. The high level methodology is documented in [agentic_framework.md](docs/agentic_framework.md). Domain workflows are listed in [domain_workflow_list.md](agent_templates/domain_workflow_list.md).
 
 ---
 

--- a/side_panel.py
+++ b/side_panel.py
@@ -21,6 +21,7 @@ class SidePanelUI:
         self.thoughts: list[str] = []
         logger.remove()
         logger.add(self._log_sink, format="{message}", level="INFO")
+        logger.info("SidePanelUI initialized")
 
     def _log_sink(self, message: str):
         self.logs.append(message)
@@ -36,8 +37,8 @@ class SidePanelUI:
     async def run(self):
         agents = {"manus": Manus()}
         prompt = input("Enter your prompt: ").strip()
-        if not prompt:
-            logger.warning("Empty prompt provided.")
+        if not prompt or len(prompt) < 3:
+            logger.warning("Invalid or empty prompt provided.")
             return
 
         flow = FlowFactory.create_flow(flow_type=FlowType.PLANNING, agents=agents)

--- a/tests/test_run_flow.py
+++ b/tests/test_run_flow.py
@@ -1,0 +1,30 @@
+import argparse
+import pytest
+
+import run_flow
+
+
+def test_validate_plan_id_valid():
+    assert run_flow._validate_plan_id("Plan_1-2") == "Plan_1-2"
+
+
+def test_validate_plan_id_invalid():
+    with pytest.raises(argparse.ArgumentTypeError):
+        run_flow._validate_plan_id("bad id!")
+
+
+def test_parse_args_plan_id():
+    args = run_flow.parse_args(["task", "--plan-id", "ABC123"])
+    assert args.plan_id == "ABC123"
+
+
+@pytest.mark.sit
+def test_parse_args_verbose():
+    args = run_flow.parse_args(["do", "--verbose"])
+    assert args.verbose
+
+
+@pytest.mark.uat
+def test_parse_args_list_tools():
+    args = run_flow.parse_args(["something", "--list-tools"])
+    assert args.list_tools


### PR DESCRIPTION
## Summary
- add plan id validator and argument logging
- improve CLI logging and lazy-load Manus
- improve side panel prompt validation
- log session creation in chat UI
- handle missing optional deps in LLM and fix Message helpers
- add agentic framework guide
- document new guide in README
- test CLI argument parsing

## Testing
- `pytest -q`