### PR TITLE
Add release Dockerfile and deployment docs

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+# Release image for quick evaluation
+WORKDIR /app/PhManus
+
+COPY . .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+EXPOSE 5000
+
+CMD ["python", "main.py"]

--- a/docs/deployment_framework.md
+++ b/docs/deployment_framework.md
@@ -1,0 +1,38 @@
+# Deployment Framework
+
+This guide expands on the agentic design principles to outline how to create and operate large scale AI agents.
+
+## 1. Parahelp SOP
+Use structured prompt files (`.prompt.yaml`) defining role, objective, KPIs, output format and constraints. Version these files to ensure consistent behaviour across deployments.
+
+## 2. Prompt Folding
+Decompose projects from epics to tasks so each prompt contains only the context it needs. This keeps reasoning efficient and allows small models to handle micro‑tasks.
+
+## 3. Prompt Chain
+Stage agents for planning, execution and verification. Coordinators such as a `ChainOrchestrator` or `ReflexionAgent` maintain accountability and traceability between steps.
+
+## 4. Prompt Library
+Maintain a library of versioned prompts with quality annotations and rollback history. Reusable components help new agents ramp up quickly.
+
+## 5. Debug Log Agent
+Run an internal agent that records ambiguities and failures with confidence scores. Logs provide a feedback loop for continuous improvement.
+
+## 6. FDE Agent Collaboration
+Organise agents around the development value stream: planner, builder, tester, deployer and reflexion. Well‑defined APIs or shared memory keep them isolated yet cooperative.
+
+Following these principles enables a modular and reliable approach for deploying enterprise or consumer grade AI assistants.
+
+## Release Docker Images
+For quick evaluation you can build a lightweight Docker image:
+
+```bash
+bash scripts/build-release-image.sh
+```
+
+Run the image with:
+
+```bash
+docker run -p 5000:5000 phmanus:release
+```
+
+This launches the web UI on port 5000.

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,16 @@ Or launch the side panel interface:
 python side_panel.py
 ```
 
+### Docker Quick Evaluation
+Build the release image for quick testing:
+```bash
+bash scripts/build-release-image.sh
+```
+Run it with:
+```bash
+docker run -p 5000:5000 phmanus:release
+```
+
 ### 1. Initialize the Planning Flow
 The `PlanningFlow` class is the core of the framework. It manages agents, plans, and task execution.
 
@@ -124,7 +134,7 @@ print(wf["name"])
 
 
 ## Documentation
-Additional information including the architecture overview, design goals and roadmap can be found in the [docs](./docs) directory. See [usage_demo.md](docs/usage_demo.md) for a CLI example. The [prompt_library.md](docs/prompt_library.md) file describes the standardized prompt templates. The high level methodology is documented in [agentic_framework.md](docs/agentic_framework.md). Domain workflows are listed in [domain_workflow_list.md](agent_templates/domain_workflow_list.md).
+Additional information including the architecture overview, design goals and roadmap can be found in the [docs](./docs) directory. See [usage_demo.md](docs/usage_demo.md) for a CLI example. The [prompt_library.md](docs/prompt_library.md) file describes the standardized prompt templates. The high level methodology is documented in [agentic_framework.md](docs/agentic_framework.md) and [deployment_framework.md](docs/deployment_framework.md). Domain workflows are listed in [domain_workflow_list.md](agent_templates/domain_workflow_list.md).
 
 ---
 

--- a/scripts/build-release-image.sh
+++ b/scripts/build-release-image.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+IMAGE_TAG=${1:-phmanus:release}
+if [ -n "$DOCKER_DRYRUN" ]; then
+  echo "docker build -f Dockerfile.release -t \"$IMAGE_TAG\" ."
+else
+  docker build -f Dockerfile.release -t "$IMAGE_TAG" .
+fi

--- a/tests/test_release_docker.py
+++ b/tests/test_release_docker.py
@@ -1,0 +1,23 @@
+import os
+import subprocess
+from pathlib import Path
+import pytest
+
+SCRIPT = Path("scripts/build-release-image.sh")
+
+def test_dockerfile_exists():
+    assert Path("Dockerfile.release").exists()
+
+@pytest.mark.sit
+def test_dry_run(monkeypatch, capsys):
+    monkeypatch.setenv("DOCKER_DRYRUN", "1")
+    subprocess.run(["bash", str(SCRIPT)], check=True)
+    out = capsys.readouterr().out
+    assert "Dockerfile.release" in out
+
+@pytest.mark.uat
+def test_custom_tag(monkeypatch, capsys):
+    monkeypatch.setenv("DOCKER_DRYRUN", "1")
+    subprocess.run(["bash", str(SCRIPT), "mytag"], check=True)
+    out = capsys.readouterr().out
+    assert "mytag" in out


### PR DESCRIPTION
## Summary
- add a release Dockerfile for a lightweight image
- provide script to build release images
- document deployment framework and docker usage
- update README to link new doc and show docker commands
- add basic tests for the release image builder

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install -q -r requirements.txt` *(fails due to network restrictions)*