### PR TITLE
Fix tests requiring docker release script

### DIFF
--- a/tests/test_release_docker.py
+++ b/tests/test_release_docker.py
@@ -1,23 +1,27 @@
-import os
 import subprocess
 from pathlib import Path
+
 import pytest
 
+
 SCRIPT = Path("scripts/build-release-image.sh")
+
 
 def test_dockerfile_exists():
     assert Path("Dockerfile.release").exists()
 
+
 @pytest.mark.sit
-def test_dry_run(monkeypatch, capsys):
+def test_dry_run(monkeypatch, capfd):
     monkeypatch.setenv("DOCKER_DRYRUN", "1")
     subprocess.run(["bash", str(SCRIPT)], check=True)
-    out = capsys.readouterr().out
+    out = capfd.readouterr().out
     assert "Dockerfile.release" in out
 
+
 @pytest.mark.uat
-def test_custom_tag(monkeypatch, capsys):
+def test_custom_tag(monkeypatch, capfd):
     monkeypatch.setenv("DOCKER_DRYRUN", "1")
     subprocess.run(["bash", str(SCRIPT), "mytag"], check=True)
-    out = capsys.readouterr().out
+    out = capfd.readouterr().out
     assert "mytag" in out


### PR DESCRIPTION
## Summary
- fix tests to capture output from shell script using `capfd`

## Testing
- `pre-commit run --all-files`
- `pytest -q`