### PR TITLE
Fix Unicode string in Web UIs

### DIFF
--- a/chat_ui.py
+++ b/chat_ui.py
@@ -52,11 +52,13 @@ def respond(message, history):
     return asyncio.run(sess.generate(message))
 
 
+MARKETPLACE_LINK = (
+    "<a href='https://github.com/modelcontextprotocol/servers' "
+    "target='_blank'>\U0001F4BE MCP Servers Marketplace</a>"
+)
+
 with gr.Blocks() as chatbot:
-    gr.Markdown(
-        "<a href='https://github.com/modelcontextprotocol/servers' target='_blank'>"
-        "\ud83d\udcbe MCP Servers Marketplace</a>"
-    )
+    gr.Markdown(MARKETPLACE_LINK)
     gr.ChatInterface(
         respond,
         title="Manus Chat",
@@ -65,7 +67,14 @@ with gr.Blocks() as chatbot:
 
 
 def launch():
-    chatbot.launch(server_name="0.0.0.0", server_port=7860)
+    try:
+        chatbot.launch(server_name="0.0.0.0", server_port=7860)
+    except ValueError as exc:  # pragma: no cover - runtime environment guard
+        if "localhost is not accessible" in str(exc):
+            logger.warning("localhost not accessible, launching with share=True")
+            chatbot.launch(server_name="0.0.0.0", server_port=7860, share=True)
+        else:
+            raise
 
 
 if __name__ == "__main__":

--- a/open_webui.py
+++ b/open_webui.py
@@ -62,10 +62,13 @@ def get_session() -> ChatSession:
     return session
 
 
+MARKETPLACE_LINK = (
+    "<a href='https://github.com/modelcontextprotocol/servers' "
+    "target='_blank'>\U0001F4BE MCP Servers Marketplace</a>"
+)
+
 with gr.Blocks() as open_webui:
-    gr.Markdown(
-        "<a href='https://github.com/modelcontextprotocol/servers' target='_blank'>\ud83d\udcbe MCP Servers Marketplace</a>"
-    )
+    gr.Markdown(MARKETPLACE_LINK)
     with gr.Row():
         with gr.Column(scale=3):
             chatbot = gr.Chatbot()
@@ -99,7 +102,16 @@ with gr.Blocks() as open_webui:
 
 
 def launch():
-    open_webui.launch(server_name="0.0.0.0", server_port=7860)
+    try:
+        open_webui.launch(server_name="0.0.0.0", server_port=7860)
+    except ValueError as exc:  # pragma: no cover - runtime environment guard
+        if "localhost is not accessible" in str(exc):
+            logger.warning("localhost not accessible, launching with share=True")
+            open_webui.launch(
+                server_name="0.0.0.0", server_port=7860, share=True
+            )
+        else:
+            raise
 
 
 if __name__ == "__main__":

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,8 @@ Launch the Open Web UI with a side panel:
 ```bash
 python open_webui.py
 ```
+If you encounter a ValueError about localhost accessibility, the script will
+automatically retry with `share=True` to generate a public link.
 
 ### Docker Quick Evaluation
 Build the release image for quick testing:

--- a/tests/test_chat_ui.py
+++ b/tests/test_chat_ui.py
@@ -41,3 +41,22 @@ async def test_user_acceptance(monkeypatch):
     session = chat_ui.get_session()
     result = await session.generate("another message")
     assert result == "dummy response"
+
+
+def test_marketplace_link_utf8():
+    encoded = chat_ui.MARKETPLACE_LINK.encode("utf-8")
+    assert b"MCP Servers Marketplace" in encoded
+
+
+def test_launch_fallback(monkeypatch):
+    calls = []
+
+    def fake_launch(*args, **kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise ValueError("When localhost is not accessible, a shareable link must be created")
+
+    monkeypatch.setattr(chat_ui.chatbot, "launch", fake_launch)
+    chat_ui.launch()
+    assert len(calls) == 2
+    assert calls[1].get("share") is True

--- a/tests/test_open_webui.py
+++ b/tests/test_open_webui.py
@@ -80,3 +80,23 @@ def test_recent_helpers(monkeypatch):
     session.logs = ["a", "b", "c"]
     assert session.get_recent_logs(2) == ["b", "c"]
     assert session.get_recent_thoughts(2) == ["user: hi", "assistant: hey"]
+
+
+def test_marketplace_link_utf8():
+    # ensure constant uses valid unicode that can be encoded
+    encoded = open_webui.MARKETPLACE_LINK.encode("utf-8")
+    assert b"MCP Servers Marketplace" in encoded
+
+
+def test_launch_fallback(monkeypatch):
+    calls = []
+
+    def fake_launch(*args, **kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise ValueError("When localhost is not accessible, a shareable link must be created")
+
+    monkeypatch.setattr(open_webui.open_webui, "launch", fake_launch)
+    open_webui.launch()
+    assert len(calls) == 2
+    assert calls[1].get("share") is True


### PR DESCRIPTION
## Summary
- use actual emoji for marketplace link so orjson can render
- retry web UIs with share=True if localhost is not accessible
- add unit/SIT/UAT tests for new behaviour
- document the share=True fallback in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ddc65ac4c8332a51e84c48721c1f2